### PR TITLE
Update the pub_date and changed logic 

### DIFF
--- a/scraper/spiders/__init__.py
+++ b/scraper/spiders/__init__.py
@@ -9,12 +9,13 @@ from scraper.utils import (
     get_setting_limits,
     get_out_dir,
     get_meta_description,
-    get_pub_and_author_info,
+    get_author_info,
     get_story_body,
     get_author_div_text,
     get_author_headshot_url,
     get_author_website_url,
     get_author_social_urls,
+    get_meta_content,
 )
 from scraper.db_settings import execution_path
 import logging
@@ -85,18 +86,14 @@ class SmtStories(CrawlSpider):
         item['canonical_url'] = html.head.find('link', rel='canonical')['href']
         item['meta_description'] = get_meta_description(html)
         item['story_title'] = html.body.find('div', property='dc:title').h3.a.text
-        (
-            item['byline'],
-            item['contributor_profile_url'],
-            item['pub_date']
-        ) = get_pub_and_author_info(html)
+        item['byline'], item['contributor_profile_url'] = get_author_info(html)
         item['body'] = get_story_body(html)
-        item['changed'] = db_data['changed']
         item['node_id'] = db_data['nid']
         item['contributor_email'] = db_data['user_email']
         item['contributor_uid'] = db_data['uid']
         item['legacy_content_type'] = db_data['content_type']
-
+        item['changed'] = get_meta_content(html, 'article:modified_time', '1776-07-04T06:30:00-00:00')
+        item['pub_date'] = get_meta_content(html, 'article:published_time', '1776-07-04T06:30:00-00:00')
         update_url_feed(response.url, spider=self)
         return item
 

--- a/scraper/utils.py
+++ b/scraper/utils.py
@@ -153,27 +153,24 @@ def get_author_website_url(page):
     return None
 
 
-def get_pub_and_author_info(page):
+def get_author_info(page):
     author_name = None
-    pub_date = None
     author_link = None
-    pub_date_div = page.body.find(
+    pub_div = page.body.find(
         'div',
         {'class': 'field-name-post-date-author-name'}
     )
 
-    if pub_date_div:
-        author_name = pub_date_div.p.a.text
-        pub_date = pub_date_div.p.text.replace(author_name, '').strip()
-        author_link = pub_date_div.p.a['href']
-    return author_name, author_link, pub_date
+    if pub_div:
+        author_name = pub_div.p.a.text
+        author_link = pub_div.p.a['href']
+    return author_name, author_link
 
 
 def get_author_social_urls(page):
     social_network_link_ids = [
         'facebook',
         'twitter',
-        'linkedin',
         'google',
     ]
     social_network_links = {}
@@ -204,3 +201,11 @@ def get_story_body(page):
     body_div = page.body.find('div', {'class': 'field-name-body'})
     body_content_div = body_div.find('div', {'property': 'content:encoded'})
     return printable(body_content_div.decode_contents(formatter="html"))
+
+
+def get_meta_content(html, property_name, default_return):
+    meta_property = html.head.find('meta', {'property': property_name})
+    if meta_property:
+        content = meta_property.get('content', default_return)
+        return content
+    return default_return


### PR DESCRIPTION
[TECH-1849](https://industrydive.atlassian.net/browse/TECH-1849)

per gitlog:
Update the pub_date and changed logic  so that the values come from meta data content instead of trying to parse if from the byline.

Returns a default of 07/04/1776 when this is not available because America.

To verify, follow steps in README to get the thing running and execute the smt_crawer.py with a small limit. OR just look at the attached output files:

[authors.jl.txt](https://github.com/industrydive/smt-scrapy/files/1075756/authors.jl.txt)
[log.txt](https://github.com/industrydive/smt-scrapy/files/1075758/log.txt)
[stories.jl.txt](https://github.com/industrydive/smt-scrapy/files/1075757/stories.jl.txt)
