### PR TITLE
TECH-1891 Story Title Bugfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,4 @@
 urllog.txt
 *log
 .DS_Store
-tox.ini
 *.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 *.html
 urllog.txt
 *log
+.DS_Store
+tox.ini
+*.pyc

--- a/crawl_smt.py
+++ b/crawl_smt.py
@@ -40,15 +40,6 @@ offset = int(args.offset or DEFAULT_OFFSET)
 end = offset + limit
 out_dir = 'output/%s-%s' % (offset, end)
 
-logging.basicConfig(level=logging.DEBUG)
-fileHandler = logging.FileHandler('%s/log' % out_dir)
-fileHandler.setFormatter(logFormatter)
-rootLogger.addHandler(fileHandler)
-
-logging.info(" >>>>>>>>>>>>>>>>>> START")
-logging.info("start record: %d" % offset)
-logging.info("end record: %d" % end)
-
 if not os.path.exists('.crawl_smt'):
     os.makedirs('.crawl_smt')
 settings_file = open('.crawl_smt/settings.txt', 'w+')
@@ -57,6 +48,15 @@ settings_file.close()
 
 if not os.path.exists(out_dir):
     os.makedirs(out_dir)
+
+logging.basicConfig(level=logging.DEBUG)
+fileHandler = logging.FileHandler('%s/log' % out_dir)
+fileHandler.setFormatter(logFormatter)
+rootLogger.addHandler(fileHandler)
+
+logging.info(" >>>>>>>>>>>>>>>>>> START")
+logging.info("start record: %d" % offset)
+logging.info("end record: %d" % end)
 
 starttime = datetime.datetime.now()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,5 @@ six==1.10.0
 Twisted==17.1.0
 w3lib==1.17.0
 zope.interface==4.4.0
+beautifulsoup4==4.5.3
+MySQL-python==1.2.5

--- a/scraper/spiders/__init__.py
+++ b/scraper/spiders/__init__.py
@@ -85,7 +85,7 @@ class SmtStories(CrawlSpider):
         item['title'] = html.head.title.text
         item['canonical_url'] = html.head.find('link', rel='canonical')['href']
         item['meta_description'] = get_meta_description(html)
-        item['story_title'] = html.body.find('div', property='dc:title').h3.a.text
+        item['story_title'] = html.body.find('section', id='section-content').find('div', property="dc:title").h3.text
         item['byline'], item['contributor_profile_url'] = get_author_info(html)
         item['body'] = get_story_body(html)
         item['node_id'] = db_data['nid']

--- a/scraper/utils.py
+++ b/scraper/utils.py
@@ -171,6 +171,7 @@ def get_author_social_urls(page):
     social_network_link_ids = [
         'facebook',
         'twitter',
+        'linkedin',
         'google',
     ]
     social_network_links = {}

--- a/test_crawl_smt.py
+++ b/test_crawl_smt.py
@@ -1,0 +1,126 @@
+# this is just crawl_smt + some stuff to track the number of titles
+# and story titles
+
+import subprocess
+import json
+import datetime
+import argparse
+import os
+import logging
+
+logFormatter = logging.Formatter("%(asctime)s\t[%(levelname)s]\t%(message)s")
+rootLogger = logging.getLogger()
+
+DEFAULT_LIMIT = 1000
+DEFAULT_OFFSET = 0
+
+parser = argparse.ArgumentParser(
+    description=(
+        'Manager for running a scrapy script for SMT stories & authors'
+    )
+)
+
+parser.add_argument(
+    '--limit',
+    help='INT: limit initial node query',
+    dest='limit',
+    type=int,
+    required=False
+)
+
+parser.add_argument(
+    '--offset',
+    help='INT: offset initial node query',
+    dest='offset',
+    type=int,
+    required=False
+)
+args = parser.parse_args()
+
+limit = int(args.limit or DEFAULT_LIMIT)
+offset = int(args.offset or DEFAULT_OFFSET)
+
+end = offset + limit
+out_dir = 'output/%s-%s' % (offset, end)
+
+if not os.path.exists('.crawl_smt'):
+    os.makedirs('.crawl_smt')
+settings_file = open('.crawl_smt/settings.txt', 'w+')
+settings_file.write('%d,%d,%s' % (limit, offset, out_dir))
+settings_file.close()
+
+if not os.path.exists(out_dir):
+    os.makedirs(out_dir)
+
+logging.basicConfig(level=logging.DEBUG)
+fileHandler = logging.FileHandler('%s/log' % out_dir)
+fileHandler.setFormatter(logFormatter)
+rootLogger.addHandler(fileHandler)
+
+logging.info(" >>>>>>>>>>>>>>>>>> START")
+logging.info("start record: %d" % offset)
+logging.info("end record: %d" % end)
+
+starttime = datetime.datetime.now()
+
+outfile_story = '%s/stories.jl' % out_dir
+outfile_author = '%s/authors.jl' % out_dir
+
+
+first_commad = 'scrapy crawl stories --output=%s --output-format=jsonlines' % outfile_story
+logging.info("running command: `%s`" % first_commad)
+
+process = subprocess.Popen(first_commad, shell=True)
+process.wait()
+print process.returncode
+
+second_commad = 'scrapy crawl authors --output=%s --output-format=jsonlines' % outfile_author
+logging.info("running command: `%s`" % second_commad)
+
+process = subprocess.Popen(second_commad, shell=True)
+process.wait()
+print process.returncode
+
+
+endtime = datetime.datetime.now()
+total_time = endtime - starttime
+
+unique_urls = []
+unique_titles = []
+unique_story_titles = []
+contributor_count = 0
+article_count = 0
+
+try:
+    with open(outfile_story) as result_file:
+        for line in result_file:
+            line_data = json.loads(line)
+            if line_data['url'] not in unique_urls:
+                unique_urls.append(line_data['url'])
+                article_count += 1
+            unique_titles.append(line_data['title'])
+            unique_story_titles.append(line_data['story_title'])
+        unique_titles = set(unique_titles)
+        unique_story_titles = set(unique_story_titles)
+except Exception:
+    print "couldn't open stories.jl"
+    logging.error("couldn't open stories.jl")
+
+try:
+    with open(outfile_author) as result_file:
+        for line in result_file:
+            line_data = json.loads(line)
+            if line_data['url'] not in unique_urls:
+                unique_urls.append(line_data['url'])
+                contributor_count += 1
+except Exception:
+    print "couldn't open authors.jl"
+    logging.error("couldn't open authors.jl")
+
+logging.info("%d unique urls scraped" % len(unique_urls))
+logging.info("%d articles parsed" % article_count)
+logging.info("%d titles" % len(unique_titles))
+logging.info("%d story titles" % len(unique_story_titles))
+logging.info("%d profiles parsed" % contributor_count)
+logging.info("Total time: %s" % total_time)
+logging.info(" >>>>>>>>>>>>>>>>>> END\n")


### PR DESCRIPTION
** Which issue(s) does this PR address? **

[TECH-1891: Story_title is the same for every smt story in the scraped data](https://industrydive.atlassian.net/browse/TECH-1891)

** What does this PR do? **

This PR fixes the issue of the story_title being set to the same value for every SMT story in the scraped data. Instead of setting story_title to the text in the text in the first "dc:title"
attribute, usually one of the links in the header menu, story_title is now assigned the value of the text in the first "dc:title" attribute in the ** section#section-content **. This finds the title that is displayed in the article.

It also adds a convenience testing script -- test_crawl_smt.py

** Where should the reviewer start? **

Run the included `test_crawl_smt.py` file. Notice that the number of unique story_titles = the number of unique titles

** How should this be manually tested? **

- Download only the `test_crawl_smt.py` file (or make the changes manually). 
- Execute `python test_crawl_smt.py --limit 10`
- Notice that the number of titles differs from the number of story titles
- Checkout this branch
- Execute `python test_crawl_smt.py --limit 10`
- Notice that the number of titles is the same as the number of story titles