### PR TITLE
Tech 2258 missing scrape data

### DIFF
--- a/scraper/spiders/__init__.py
+++ b/scraper/spiders/__init__.py
@@ -164,26 +164,6 @@ class SocialMediaToday(scrapy.Spider):
             if field_value:
                 item[item_key] = field_value.strip()
 
-        bio = body.css('.field-name-field-user-biography div div::text').extract_first()
-        fullname = body.css('.field-name-user-full-name div div a strong::text').extract_first() + response.css(
-            '.field-name-user-full-name div div a::text'
-        ).extract_first()
-        job_title = body.css('.field-name-field-user-job-title div div.field-item::text').extract_first()
-        company_name = body.css('.field-name-field-user-company-name div.field-item::text').extract_first()
-        twitter = body.css('.field-name-field-user-twitter-url div div.field-item a::text').extract_first()
-        facebook = body.css('.field-name-field-user-facebook-url div div.field-item a::text').extract_first()
-        linkedin = body.css('.field-name-field-user-linkedin-url div div.field-item a::text').extract_first()
-        google = body.css('.field-name-field-user-google-url div div.field-item a::text').extract_first()
-
-        item['google'] = google.strip()
-        item['linkedin'] = linkedin.strip()
-        item['facebook'] = facebook.strip()
-        item['twitter'] = twitter.strip()
-        item['company_name'] = company_name.strip()
-        item['job_title'] = job_title.strip()
-        item['fullname'] = fullname.strip()
-        item['bio'] = bio.strip()
-
         headshot_url = body.css(
             'div.field-name-ds-user-picture img::attr(src)').extract_first()
         item['headshot_url'] = headshot_url or ''

--- a/scraper/spiders/__init__.py
+++ b/scraper/spiders/__init__.py
@@ -159,7 +159,7 @@ class SocialMediaToday(scrapy.Spider):
         for item_key, field_key in USER_FIELD_MAP.items():
             # Default to empty string.
             item[item_key] = ''
-            full_selector = 'div.{} div.field-item::text'.format(field_key)
+            full_selector = 'div.{} div.field-item'.format(field_key)
             field_value = body.css(full_selector).extract_first()
             if field_value:
                 item[item_key] = field_value.strip()


### PR DESCRIPTION
Removes the ::text css pseudo selector from the selections. Also reverts a previous commit i accidentally made to master last night.


This solution will require us to munge some of the html out of these field as part of mr-clean's operations. 