### PR TITLE
Maybe fix the social networks too by removing the even css seelctor

### DIFF
--- a/scraper/spiders/__init__.py
+++ b/scraper/spiders/__init__.py
@@ -11,17 +11,13 @@ USER_FIELD_MAP = {
 
 SOCIAL_NETWORKS = {
     'facebook':
-        'div.field-name-field-user-facebook-url div.field-item even '
-        'a::attr(href)',
+        'div.field-name-field-user-facebook-url div.field-item a::attr(href)',
     'twitter':
-        'div.field-name-field-user-twitter-url div.field-item even '
-        'a::attr(href)',
+        'div.field-name-field-user-twitter-url div.field-item a::attr(href)',
     'linkedin':
-        'div.field-name-field-user-linkedin-url div.field-item even '
-        'a::attr(href)',
+        'div.field-name-field-user-linkedin-url div.field-item a::attr(href)',
     'google':
-        'div.field-name-field-user-google-url div.field-item even '
-        'a::attr(href)',
+        'div.field-name-field-user-google-url div.field-item a::attr(href)',
 }
 
 


### PR DESCRIPTION
PR to add social networks back by removing the 'even' from the css selector. this seemed to work in the console. 



```
response.css('div.field-name-field-user-facebook-url div.field-item a::attr(href)').extract_first()
2017-08-18 14:49:58 [stdout] INFO: u'https://www.facebook.com/adhservices'
2017-08-18 14:49:58 [stdout] INFO: >>>
response.css('div.field-name-field-user-facebook-url div.field-item even a::attr(href)').extract_first()
2017-08-18 14:50:11 [stdout] INFO: >>>

```