### PR TITLE
Use first and last name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,12 +26,12 @@ jobs:
       - store_artifacts:
           path: artifacts
           destination: artifacts
-      - deploy:
-          name: Deploy Master to ScrapingHub Cloud
-          command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then
-              . venv/bin/activate
-              pip install shub
-              echo "apikeys:\n  default: ${SHUB_API_KEY}" > ~/.scrapinghub.yml
-              shub deploy --version ${CIRCLE_BUILD_NUM}
-            fi
+      # - deploy:
+      #     name: Deploy Master to ScrapingHub Cloud
+      #     command: |
+      #       if [ "${CIRCLE_BRANCH}" == "master" ]; then
+      #         . venv/bin/activate
+      #         pip install shub
+      #         echo "apikeys:\n  default: ${SHUB_API_KEY}" > ~/.scrapinghub.yml
+      #         shub deploy --version ${CIRCLE_BUILD_NUM}
+      #       fi

--- a/scraper/items.py
+++ b/scraper/items.py
@@ -8,6 +8,22 @@
 import scrapy
 
 
+class SmtArticleItem(scrapy.Item):
+    """
+    Represents the content of an Article page as a scrapy Item object.
+    """
+    page_type = scrapy.Field()
+    url = scrapy.Field()
+    node_id = scrapy.Field()
+    contributor_uid = scrapy.Field()
+    category = scrapy.Field()
+    title = scrapy.Field()
+    canonical_url = scrapy.Field()
+    pub_date = scrapy.Field()
+    byline = scrapy.Field()
+    body = scrapy.Field()
+
+
 class SmtContributorProfileItem(scrapy.Item):
     """
     Represents the content of a Contributor Profile page as a scrapy Item
@@ -15,39 +31,15 @@ class SmtContributorProfileItem(scrapy.Item):
     """
     page_type = scrapy.Field()
     uid = scrapy.Field()
-    email = scrapy.Field()
     url = scrapy.Field()
-    title = scrapy.Field()
-    page_title = scrapy.Field()
-    fullname = scrapy.Field()
+    first_name = scrapy.Field()
+    last_name = scrapy.Field()
     company_name = scrapy.Field()
     job_title = scrapy.Field()
     headshot_url = scrapy.Field()
     website = scrapy.Field()
+    bio = scrapy.Field()
     facebook = scrapy.Field()
-    twitter = scrapy.Field()
     linkedin = scrapy.Field()
     google = scrapy.Field()
-    bio = scrapy.Field()
-
-
-class SmtArticleItem(scrapy.Item):
-    """
-    Represents the content of an Article page as a scrapy Item object.
-    """
-    page_type = scrapy.Field()
-    node_id = scrapy.Field()
-    url = scrapy.Field()
-    title = scrapy.Field()
-    canonical_url = scrapy.Field()
-    meta_description = scrapy.Field()
-    story_title = scrapy.Field()
-    body = scrapy.Field()
-    pub_date = scrapy.Field()
-    byline = scrapy.Field()
-    changed = scrapy.Field()
-    contributor_profile_url = scrapy.Field()
-    contributor_email = scrapy.Field()
-    contributor_uid = scrapy.Field()
-    legacy_content_type = scrapy.Field()
-    category = scrapy.Field()
+    twitter_handle = scrapy.Field()

--- a/scraper/settings.py
+++ b/scraper/settings.py
@@ -128,6 +128,5 @@ FEED_EXPORT_ENCODING = 'utf-8'
 FEED_STORE_EMPTY = True
 
 START_URLS = [
-    'http://www---smt-import-20170809-wq4zreq-3faqimkzadf6s.us.platform.sh'
-    '/all-stories?x=1'
+    'http://direct---import-20170821-sirgvpy-3faqimkzadf6s.us.platform.sh/all-stories?x=2'
 ]

--- a/scraper/spiders/__init__.py
+++ b/scraper/spiders/__init__.py
@@ -103,28 +103,12 @@ class SocialMediaToday(scrapy.Spider):
         canonical_url = head.css('link[rel=canonical]::attr(href)').extract_first() or ''
         item['canonical_url'] = canonical_url.strip()
 
-        # We don't use meta description in the import at all.
-        # desc = head.css('meta[name=description]::attr(content)').extract_first() or ''
-        # item['meta_description'] = desc.strip()
-
-        # We don't use changed in the import at all.
-        # changed = head.css('meta[property="article:modified_time"]::attr(content)').extract_first() or ''
-        # item['changed'] = changed.strip()
-
         pub_date = head.css('meta[property="article:published_time"]::attr(content)').extract_first() or ''
         item['pub_date'] = pub_date.strip()
-
-        # We don't use the story_title in the import at all.
-        # story_title = body.css('section#section-content div[property="dc:title"] h3::text').extract_first() or ''
-        # item['story_title'] = story_title.strip()
 
         author_link = body.css('div.field-name-post-date-author-name .field-item p a')
         byline = author_link.css('::text').extract_first() or ''
         item['byline'] = byline.strip()
-
-        # We don't use this in the import.
-        # contributor_profile_url = author_link.css('::attr(href)').extract_first() or ''
-        # item['contributor_profile_url'] = contributor_profile_url.strip()
 
         body_content = body.css('div.field-name-body div[property="content:encoded"]').extract_first() or ''
         item['body'] = body_content.strip()

--- a/scraper/spiders/__init__.py
+++ b/scraper/spiders/__init__.py
@@ -103,23 +103,28 @@ class SocialMediaToday(scrapy.Spider):
         canonical_url = head.css('link[rel=canonical]::attr(href)').extract_first() or ''
         item['canonical_url'] = canonical_url.strip()
 
-        desc = head.css('meta[name=description]::attr(content)').extract_first() or ''
-        item['meta_description'] = desc.strip()
+        # We don't use meta description in the import at all.
+        # desc = head.css('meta[name=description]::attr(content)').extract_first() or ''
+        # item['meta_description'] = desc.strip()
 
-        changed = head.css('meta[property="article:modified_time"]::attr(content)').extract_first() or ''
-        item['changed'] = changed.strip()
+        # We don't use changed in the import at all.
+        # changed = head.css('meta[property="article:modified_time"]::attr(content)').extract_first() or ''
+        # item['changed'] = changed.strip()
 
         pub_date = head.css('meta[property="article:published_time"]::attr(content)').extract_first() or ''
         item['pub_date'] = pub_date.strip()
 
-        story_title = body.css('section#section-content div[property="dc:title"] h3::text').extract_first() or ''
-        item['story_title'] = story_title.strip()
+        # We don't use the story_title in the import at all.
+        # story_title = body.css('section#section-content div[property="dc:title"] h3::text').extract_first() or ''
+        # item['story_title'] = story_title.strip()
 
         author_link = body.css('div.field-name-post-date-author-name .field-item p a')
         byline = author_link.css('::text').extract_first() or ''
         item['byline'] = byline.strip()
-        contributor_profile_url = author_link.css('::attr(href)').extract_first() or ''
-        item['contributor_profile_url'] = contributor_profile_url.strip()
+
+        # We don't use this in the import.
+        # contributor_profile_url = author_link.css('::attr(href)').extract_first() or ''
+        # item['contributor_profile_url'] = contributor_profile_url.strip()
 
         body_content = body.css('div.field-name-body div[property="content:encoded"]').extract_first() or ''
         item['body'] = body_content.strip()
@@ -138,8 +143,8 @@ class SocialMediaToday(scrapy.Spider):
         body = response.css('body')
 
         item = SmtContributorProfileItem()
-        item['uid'] = response.meta['uid']
         item['page_type'] = 'contributor profile'
+        item['uid'] = response.meta['uid']
         item['url'] = response.url
 
         # First name is plain text.

--- a/scraper/spiders/__init__.py
+++ b/scraper/spiders/__init__.py
@@ -2,12 +2,6 @@ import scrapy
 
 from scraper.items import SmtArticleItem, SmtContributorProfileItem
 
-USER_FIELD_MAP = {
-    'bio': 'field-name-field-user-biography',
-    'fullname': 'field-name-user-full-name',
-    'company_name': 'field-name-field-user-company-name',
-    'job_title': 'field-name-field-user-job-title'
-}
 
 SOCIAL_NETWORKS = {
     'facebook':
@@ -157,30 +151,30 @@ class SocialMediaToday(scrapy.Spider):
         item['page_type'] = 'contributor profile'
         item['url'] = response.url
 
-        for item_key, field_key in USER_FIELD_MAP.items():
-            # Default to empty string.
-            item[item_key] = ''
-            full_selector = 'div.{} div.field-item'.format(field_key)
-            field_value = body.css(full_selector).extract_first()
-            if field_value:
-                item[item_key] = field_value.strip()
+        first_name = body.css('.scrapy-first-name::text').extract_first() or ''
+        item['first_name'] = first_name.strip()
 
-        headshot_url = body.css(
-            'div.field-name-ds-user-picture img::attr(src)').extract_first()
-        item['headshot_url'] = headshot_url or ''
+        last_name = body.css('.scrapy-last-name::text').extract_first() or ''
+        item['last_name'] = last_name.strip()
 
-        website = body.css(
-            'div.field-name-field-user-website .field-item a::attr(href)')\
-            .extract_first()
-        item['website'] = website or ''
+        company_name = body.css('.field-name-field-user-company-name .field-item::text').extract_first() or ''
+        item['company_name'] = company_name.strip()
+
+        job_title = body.css('.field-name-field-user-job-title .field-item::text').extract_first() or ''
+        item['job_title'] = job_title.strip()
+
+        headshot_url = body.css('.field-name-ds-user-picture img::attr(src)').extract_first() or ''
+        item['headshot_url'] = headshot_url.strip()
+
+        website = body.css('.field-name-field-user-website .field-item a::attr(href)').extract_first() or ''
+        item['website'] = website.strip()
+
+        # This is the only html field.
+        bio = body.css('.field-name-field-user-biography .field-item').extract_first() or ''
+        item['bio'] = bio.strip()
 
         for network_key, selector in SOCIAL_NETWORKS.items():
-            # Default to empty string.
-            item[network_key] = ''
-
-            href = body.css(selector).extract_first()
-
-            if href:
-                item[network_key] = href.strip()
+            href = body.css(selector).extract_first() or ''
+            item[network_key] = href.strip()
 
         yield item

--- a/tox.ini
+++ b/tox.ini
@@ -8,3 +8,4 @@ exclude =
   venv
 statistics = True
 max-complexity = 10
+max-line-length = 120


### PR DESCRIPTION
Split out first and last name based on some extra CSS classes I added.

Also handle the plain text fields correctly. I checked the site configuration to see that most fields are expected to be plain text. The only exception is the bio, which we'll need to clean later on.

I also removed fields we don't currently use in the import and simplified some other fields. This might help speed up life or at least cut down on export file size, maybe.

